### PR TITLE
Fix linting errors: remove unused variables

### DIFF
--- a/src/app/[variants]/(main)/discover/(detail)/assistant/[...slugs]/features/Details/Nav.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/assistant/[...slugs]/features/Details/Nav.tsx
@@ -32,7 +32,7 @@ interface NavProps {
 
 const Nav = memo<NavProps>(({ mobile, setActiveTab, activeTab = AssistantNavKey.Overview }) => {
   const { t } = useTranslation('discover');
-  const { pluginCount, knowledgeCount, identifier } = useDetailContext();
+  const { pluginCount, knowledgeCount } = useDetailContext();
   const { styles } = useStyles();
 
   const capabilitiesCount = Number(pluginCount) + Number(knowledgeCount);

--- a/src/app/[variants]/(main)/discover/(detail)/provider/[...slugs]/features/Details/Nav.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/provider/[...slugs]/features/Details/Nav.tsx
@@ -33,7 +33,6 @@ interface NavProps {
 
 const Nav = memo<NavProps>(({ mobile, setActiveTab, activeTab = ProviderNavKey.Overview }) => {
   const { t } = useTranslation('discover');
-  const { identifier } = useDetailContext();
   const { styles } = useStyles();
 
   const nav = (

--- a/src/features/MCPPluginDetail/Nav.tsx
+++ b/src/features/MCPPluginDetail/Nav.tsx
@@ -53,7 +53,6 @@ const Nav = memo<NavProps>(
       toolsCount,
       resourcesCount,
       promptsCount,
-      github,
       identifier,
     } = useDetailContext();
     const { styles } = useStyles();

--- a/src/server/sitemap.ts
+++ b/src/server/sitemap.ts
@@ -288,7 +288,6 @@ export class Sitemap {
   }
 
   async getPage(): Promise<MetadataRoute.Sitemap> {
-    const hideDocs = serverFeatureFlags().hideDocs;
     return [
       ...this._genSitemap('/', { noLocales: true }),
       ...this._genSitemap('/chat', { noLocales: true }),


### PR DESCRIPTION
- Remove unused 'identifier' variable from assistant Nav component
- Remove unused 'identifier' variable from provider Nav component
- Remove unused 'github' variable from MCPPluginDetail Nav component
- Remove unused 'hideDocs' variable from sitemap.ts

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Remove unused variables across components to address linting errors

Bug Fixes:
- Remove unused identifier variable in assistant and provider Nav components
- Remove unused github variable in MCPPluginDetail Nav component
- Remove unused hideDocs flag in sitemap.ts